### PR TITLE
build-ta-lib-wheels

### DIFF
--- a/build-ta-lib-wheels.yml
+++ b/build-ta-lib-wheels.yml
@@ -1,0 +1,93 @@
+name: Build TA-Lib wheels for Windows
+
+on:
+  workflow_dispatch:
+
+env:
+  TALIB_C_VER: 0.4.0
+  TALIB_PY_VER: 0.4.29
+  PIP_NO_VERIFY: 0
+  PIP_VERBOSE: 1
+  # CIBW_ENVIRONMENT: "PIP_PRE=1"
+  CIBW_BUILD_VERBOSITY: 3
+  CIBW_BEFORE_BUILD: pip install -U setuptools wheel numpy==2.0.0rc2 Cython
+  CIBW_TEST_REQUIRES: pytest pandas polars
+  CIBW_TEST_COMMAND: >
+    cd .. &&
+    pytest --rootdir=C: -k "not RSI and not threading" {project}\tests
+  CIBW_TEST_SKIP: "*win32"
+  CIBW_SKIP: "pp* cp36* cp37* cp38*"
+  MSBUILDTREATHIGHERTOOLSVERSIONASCURRENT: 1
+
+jobs:
+  build_amd64:
+    name: Build AMD64 wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-2022]
+    env:
+      VS_PLATFORM: x64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
+      - run: build.cmd
+        shell: cmd
+      - uses: pypa/cibuildwheel@v2.18.1
+        env:
+          CIBW_ARCHS_WINDOWS: AMD64
+          CIBW_ENVIRONMENT_WINDOWS: LIB="ta-lib\\c\\ide\\vs2022\\lib_proj\\$VS_PLATFORM\\cdr;$LIB" PIP_NO_BUILD_ISOLATION=false
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: wheels-win-amd64
+  build_x86:
+    name: Build x86 wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-2022]
+    env:
+      VS_PLATFORM: Win32
+    steps:
+      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x86
+      - run: build.cmd
+        shell: cmd
+      - uses: pypa/cibuildwheel@v2.18.1
+        env:
+          CIBW_ARCHS_WINDOWS: x86
+          CIBW_ENVIRONMENT_WINDOWS: LIB="ta-lib\\c\\ide\\vs2022\\lib_proj\\$VS_PLATFORM\\cdr;$LIB" PIP_NO_BUILD_ISOLATION=false
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: wheels-win32
+  # ARM64 wheel is broken
+  # build_arm64:
+  #  name: Build ARM64 wheels
+  #  runs-on: ${{ matrix.os }}
+  #  strategy:
+  #    matrix:
+  #      os: [windows-2022]
+  #  env:
+  #    VS_PLATFORM: ARM64
+  #  steps:
+  #    - uses: actions/checkout@v4
+  #    - uses: microsoft/setup-msbuild@v2
+  #      with:
+  #        msbuild-architecture: arm64
+  #    - run: build.cmd
+  #      shell: cmd
+  #    - uses: pypa/cibuildwheel@v2.18.1
+  #      env:
+  #        CIBW_SKIP: "pp* cp36* cp37* cp38* cp39* cp310*"
+  #        CIBW_ARCHS_WINDOWS: ARM64
+  #        CIBW_ENVIRONMENT_WINDOWS: LIB="ta-lib\\c\\ide\\vs2022\\lib_proj\\$VS_PLATFORM\\cdr;$LIB" PIP_NO_BUILD_ISOLATION=false
+  #    - uses: actions/upload-artifact@v4
+  #      with:
+  #        path: ./wheelhouse/*.whl
+  #        name: wheels-win-arm64


### PR DESCRIPTION
```
name: Build TA-Lib wheels for Windows

on:
  workflow_dispatch:

env:
  TALIB_C_VER: 0.4.0
  TALIB_PY_VER: 0.4.29
  PIP_NO_VERIFY: 0
  PIP_VERBOSE: 1
  # CIBW_ENVIRONMENT: "PIP_PRE=1"
  CIBW_BUILD_VERBOSITY: 3
  CIBW_BEFORE_BUILD: pip install -U setuptools wheel numpy==2.0.0rc2 Cython
  CIBW_TEST_REQUIRES: pytest pandas polars
  CIBW_TEST_COMMAND: >
    cd .. &&
    pytest --rootdir=C: -k "not RSI and not threading" {project}\tests
  CIBW_TEST_SKIP: "*win32"
  CIBW_SKIP: "pp* cp36* cp37* cp38*"
  MSBUILDTREATHIGHERTOOLSVERSIONASCURRENT: 1

jobs:
  build_amd64:
    name: Build AMD64 wheels
    runs-on: ${{ matrix.os }}
    strategy:
      matrix:
        os: [windows-2022]
    env:
      VS_PLATFORM: x64
    steps:
      - uses: actions/checkout@v4
      - uses: microsoft/setup-msbuild@v2
        with:
          msbuild-architecture: x64
      - run: build.cmd
        shell: cmd
      - uses: pypa/cibuildwheel@v2.18.1
        env:
          CIBW_ARCHS_WINDOWS: AMD64
          CIBW_ENVIRONMENT_WINDOWS: LIB="ta-lib\\c\\ide\\vs2022\\lib_proj\\$VS_PLATFORM\\cdr;$LIB" PIP_NO_BUILD_ISOLATION=false
      - uses: actions/upload-artifact@v4
        with:
          path: ./wheelhouse/*.whl
          name: wheels-win-amd64
  build_x86:
    name: Build x86 wheels
    runs-on: ${{ matrix.os }}
    strategy:
      matrix:
        os: [windows-2022]
    env:
      VS_PLATFORM: Win32
    steps:
      - uses: actions/checkout@v4
      - uses: microsoft/setup-msbuild@v2
        with:
          msbuild-architecture: x86
      - run: build.cmd
        shell: cmd
      - uses: pypa/cibuildwheel@v2.18.1
        env:
          CIBW_ARCHS_WINDOWS: x86
          CIBW_ENVIRONMENT_WINDOWS: LIB="ta-lib\\c\\ide\\vs2022\\lib_proj\\$VS_PLATFORM\\cdr;$LIB" PIP_NO_BUILD_ISOLATION=false
      - uses: actions/upload-artifact@v4
        with:
          path: ./wheelhouse/*.whl
          name: wheels-win32
  # ARM64 wheel is broken
  # build_arm64:
  #  name: Build ARM64 wheels
  #  runs-on: ${{ matrix.os }}
  #  strategy:
  #    matrix:
  #      os: [windows-2022]
  #  env:
  #    VS_PLATFORM: ARM64
  #  steps:
  #    - uses: actions/checkout@v4
  #    - uses: microsoft/setup-msbuild@v2
  #      with:
  #        msbuild-architecture: arm64
  #    - run: build.cmd
  #      shell: cmd
  #    - uses: pypa/cibuildwheel@v2.18.1
  #      env:
  #        CIBW_SKIP: "pp* cp36* cp37* cp38* cp39* cp310*"
  #        CIBW_ARCHS_WINDOWS: ARM64
  #        CIBW_ENVIRONMENT_WINDOWS: LIB="ta-lib\\c\\ide\\vs2022\\lib_proj\\$VS_PLATFORM\\cdr;$LIB" PIP_NO_BUILD_ISOLATION=false
  #    - uses: actions/upload-artifact@v4
  #      with:
  #        path: ./wheelhouse/*.whl
  #        name: wheels-win-arm64
```